### PR TITLE
Begin removing units from ELP.

### DIFF
--- a/romancal/dark_current/dark_current_step.py
+++ b/romancal/dark_current/dark_current_step.py
@@ -54,7 +54,7 @@ class DarkCurrentStep(RomanStep):
             # Do the dark correction
             out_model = input_model
             nresultants = len(input_model.meta.exposure["read_pattern"])
-            out_model.data -= dark_model.data[:nresultants]
+            out_model.data -= dark_model.data[:nresultants].value
             out_model.pixeldq |= dark_model.dq
             out_model.meta.cal_step.dark = "COMPLETE"
 

--- a/romancal/dark_current/tests/test_dark.py
+++ b/romancal/dark_current/tests/test_dark.py
@@ -60,7 +60,7 @@ def test_dark_step_subtraction(instrument, exptype):
 
     # populate data array of science cube
     for i in range(0, 20):
-        ramp_model.data[0, 0, i] = i * ramp_model.data.unit
+        ramp_model.data[0, 0, i] = i
         darkref_model.data[0, 0, i] = i * 0.1 * darkref_model.data.unit
     orig_model = ramp_model.copy()
 
@@ -68,12 +68,12 @@ def test_dark_step_subtraction(instrument, exptype):
     result = DarkCurrentStep.call(ramp_model, override_dark=darkref_model)
 
     # check that the dark file is subtracted frame by frame from the science data
-    diff = orig_model.data.value - darkref_model.data.value
+    diff = orig_model.data - darkref_model.data.value
 
     # test that the output data file is equal to the difference found when subtracting
     # reffile from sci file
     np.testing.assert_array_equal(
-        result.data.value, diff, err_msg="dark file should be subtracted from sci file "
+        result.data, diff, err_msg="dark file should be subtracted from sci file "
     )
 
 
@@ -148,7 +148,7 @@ def create_ramp_and_dark(shape, instrument, exptype):
     ramp.meta.instrument.detector = "WFI01"
     ramp.meta.instrument.optical_element = "F158"
     ramp.meta.exposure.type = exptype
-    ramp.data = u.Quantity(np.ones(shape, dtype=np.float32), u.DN, dtype=np.float32)
+    ramp.data = np.ones(shape, dtype=np.float32)
     ramp_model = RampModel(ramp)
 
     # Create dark model

--- a/romancal/dq_init/tests/test_dq_init.py
+++ b/romancal/dq_init/tests/test_dq_init.py
@@ -199,9 +199,7 @@ def test_dqinit_step_interface(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw[extra_key] = extra_value
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
@@ -251,9 +249,7 @@ def test_dqinit_refpix(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Create mask model
@@ -272,7 +268,7 @@ def test_dqinit_refpix(instrument, exptype):
 
     # check if reference pixels are correct
     assert result.data.shape == (2, 20, 20)  # no pixels should be trimmed
-    assert result.amp33.value.shape == (2, 4096, 128)
+    assert result.amp33.shape == (2, 4096, 128)
     assert result.border_ref_pix_right.shape == (2, 20, 4)
     assert result.border_ref_pix_left.shape == (2, 20, 4)
     assert result.border_ref_pix_top.shape == (2, 4, 20)
@@ -304,9 +300,7 @@ def test_dqinit_resultantdq(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
     wfi_sci_raw.resultantdq[1, 12, 12] = pixel["DROPOUT"]
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Create mask model
@@ -354,9 +348,7 @@ def test_dqinit_getbestref(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     # Perform Data Quality application step

--- a/romancal/flatfield/flat_field.py
+++ b/romancal/flatfield/flat_field.py
@@ -5,7 +5,6 @@ Module for applying flat fielding
 import logging
 
 import numpy as np
-from astropy import units as u
 from roman_datamodels.dqflags import pixel
 
 log = logging.getLogger(__name__)
@@ -105,9 +104,7 @@ def apply_flat_field(science, flat):
     flat_data[np.where(flat_bad)] = 1.0
     # Now let's apply the correction to science data and error arrays.  Rely
     # on array broadcasting to handle the cubes
-    science.data = u.Quantity(
-        (science.data.value / flat_data), u.DN / u.s, dtype=science.data.dtype
-    )
+    science.data = (science.data / flat_data).astype(science.data.dtype)
 
     # Update the variances using BASELINE algorithm.  For guider data, it has
     # not gone through ramp fitting so there is no Poisson noise or readnoise
@@ -121,8 +118,6 @@ def apply_flat_field(science, flat):
         science.var_flat = science.data**2 / flat_data_squared * flat_err**2
 
     science.err = np.sqrt(science.var_poisson + science.var_rnoise + science.var_flat)
-    science.err = science.err.to(science.data.unit)
-    # Workaround for https://github.com/astropy/astropy/issues/16055
 
     # Combine the science and flat DQ arrays
     science.dq = np.bitwise_or(science.dq, flat_dq)

--- a/romancal/flatfield/tests/test_flatfield.py
+++ b/romancal/flatfield/tests/test_flatfield.py
@@ -26,22 +26,12 @@ def test_flatfield_step_interface(instrument, exptype):
     wfi_image.meta.instrument.detector = "WFI01"
     wfi_image.meta.instrument.optical_element = "F158"
     wfi_image.meta.exposure.type = exptype
-    wfi_image.data = u.Quantity(
-        np.ones(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32
-    )
+    wfi_image.data =  np.ones(shape, dtype=np.float32)
     wfi_image.dq = np.zeros(shape, dtype=np.uint32)
-    wfi_image.err = u.Quantity(
-        np.zeros(shape, dtype=np.float32), u.DN / u.s, dtype=np.float32
-    )
-    wfi_image.var_poisson = u.Quantity(
-        np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32
-    )
-    wfi_image.var_rnoise = u.Quantity(
-        np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32
-    )
-    wfi_image.var_flat = u.Quantity(
-        np.zeros(shape, dtype=np.float32), u.DN**2 / u.s**2, dtype=np.float32
-    )
+    wfi_image.err = np.zeros(shape, dtype=np.float32)
+    wfi_image.var_poisson = np.zeros(shape, dtype=np.float32)
+    wfi_image.var_rnoise = np.zeros(shape, dtype=np.float32)
+    wfi_image.var_flat = np.zeros(shape, dtype=np.float32)
 
     wfi_image_model = ImageModel(wfi_image)
     flatref = stnode.FlatRef()

--- a/romancal/linearity/linearity_step.py
+++ b/romancal/linearity/linearity_step.py
@@ -56,12 +56,10 @@ class LinearityStep(RomanStep):
             # The third return value is the procesed zero frame which
             # Roman does not use.
             new_data, new_pdq, _ = linearity_correction(
-                input_model.data.value, gdq, pdq, lin_coeffs, lin_dq, pixel
+                input_model.data, gdq, pdq, lin_coeffs, lin_dq, pixel
             )
 
-            input_model.data = u.Quantity(
-                new_data[0, :, :, :], u.DN, dtype=new_data.dtype
-            )
+            input_model.data = new_data[0, :, :, :]
             input_model.pixeldq = new_pdq
 
         # Update the step status

--- a/romancal/linearity/tests/test_linearity.py
+++ b/romancal/linearity/tests/test_linearity.py
@@ -35,9 +35,7 @@ def test_linearity_coeff(instrument, exptype):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = exptype
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw)
 
     result = DQInitStep.call(wfi_sci_raw_model)

--- a/romancal/ramp_fitting/ramp_fit_step.py
+++ b/romancal/ramp_fitting/ramp_fit_step.py
@@ -101,7 +101,7 @@ class RampFitStep(RomanStep):
         if self.threshold_constant is not None:
             kwargs["threshold_constant"] = self.threshold_constant
 
-        resultants = input_model.data.value
+        resultants = input_model.data
         dq = input_model.groupdq
         read_noise = readnoise_model.data.value
         gain = gain_model.data.value
@@ -183,10 +183,6 @@ def create_image_model(input_model, image_info):
     """
     data, dq, var_poisson, var_rnoise, err = image_info
 
-    data = u.Quantity(data, u.DN / u.s, dtype=data.dtype)
-    var_poisson = u.Quantity(var_poisson, u.DN**2 / u.s**2, dtype=var_poisson.dtype)
-    var_rnoise = u.Quantity(var_rnoise, u.DN**2 / u.s**2, dtype=var_rnoise.dtype)
-    err = u.Quantity(err, u.DN / u.s, dtype=err.dtype)
     if dq is None:
         dq = np.zeros(data.shape, dtype="u4")
 
@@ -198,13 +194,11 @@ def create_image_model(input_model, image_info):
     meta["photometry"] = maker_utils.mk_photometry()
     inst = {
         "meta": meta,
-        "data": u.Quantity(data, u.DN / u.s, dtype=data.dtype),
+        "data": data,
         "dq": dq,
-        "var_poisson": u.Quantity(
-            var_poisson, u.DN**2 / u.s**2, dtype=var_poisson.dtype
-        ),
-        "var_rnoise": u.Quantity(var_rnoise, u.DN**2 / u.s**2, dtype=var_rnoise.dtype),
-        "err": u.Quantity(err, u.DN / u.s, dtype=err.dtype),
+        "var_poisson": var_poisson,
+        "var_rnoise": var_rnoise,
+        "err": err,
         "amp33": input_model.amp33.copy(),
         "border_ref_pix_left": input_model.border_ref_pix_left.copy(),
         "border_ref_pix_right": input_model.border_ref_pix_right.copy(),

--- a/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
+++ b/romancal/ramp_fitting/tests/test_ramp_fit_cas22.py
@@ -226,10 +226,10 @@ def model_from_resultants(resultants, read_pattern=None):
     gdq = np.zeros(shape=shape, dtype=np.uint8)
 
     dm_ramp = maker_utils.mk_ramp(shape=shape)
-    dm_ramp.data = u.Quantity(full_wfi, u.DN, dtype=np.float32)
+    dm_ramp.data = full_wfi
     dm_ramp.pixeldq = pixdq
     dm_ramp.groupdq = gdq
-    dm_ramp.err = u.Quantity(err, u.DN, dtype=np.float32)
+    dm_ramp.err = err
 
     dm_ramp.meta.exposure.frame_time = ROMAN_READ_TIME
     dm_ramp.meta.exposure.ngroups = shape[0]

--- a/romancal/refpix/data.py
+++ b/romancal/refpix/data.py
@@ -82,24 +82,15 @@ class StandardView(BaseView):
         - right = detector[-Const.REF:]
     """
 
-    @staticmethod
-    def extract_value(data):
-        if isinstance(data, u.Quantity):
-            if data.unit != u.DN:
-                raise ValueError(f"Input data must be in units of DN, not {data.unit}")
-            data = data.value
-
-        return data
-
     @classmethod
     def from_datamodel(cls, datamodel: RampModel) -> StandardView:
         """
         Read the datamodel into the standard view.
         """
-        detector = cls.extract_value(datamodel.data)
+        detector = datamodel.data
 
         # Extract amp33
-        amp33 = cls.extract_value(datamodel.amp33)
+        amp33 = datamodel.amp33
         # amp33 is normally a uint16, but this computation requires it to match
         # the data type of the detector pixels.
         amp33 = amp33.astype(detector.dtype)
@@ -112,23 +103,11 @@ class StandardView(BaseView):
             - Returns the updated datamodel for a functional approach.
         """
 
-        datamodel.data = u.Quantity(
-            self.detector, unit=datamodel.data.unit, dtype=datamodel.data.dtype
-        )
+        datamodel.data = self.detector
         # ABS to avoid casting negative numbers to uint16
-        datamodel.amp33 = u.Quantity(
-            np.abs(self.amp33), unit=datamodel.amp33.unit, dtype=datamodel.amp33.dtype
-        )
-        datamodel.border_ref_pix_left = u.Quantity(
-            self.left,
-            unit=datamodel.border_ref_pix_left.unit,
-            dtype=datamodel.border_ref_pix_left.dtype,
-        )
-        datamodel.border_ref_pix_right = u.Quantity(
-            self.right,
-            unit=datamodel.border_ref_pix_right.unit,
-            dtype=datamodel.border_ref_pix_right.dtype,
-        )
+        datamodel.amp33 = np.abs(self.amp33).astype(datamodel.amp33.dtype)
+        datamodel.border_ref_pix_left = self.left
+        datamodel.border_ref_pix_right = self.right
 
         return datamodel
 

--- a/romancal/refpix/tests/conftest.py
+++ b/romancal/refpix/tests/conftest.py
@@ -48,12 +48,8 @@ def datamodel(data):
     assert detector.shape == (Dims.N_FRAMES, Dims.N_ROWS, Const.N_COLUMNS)
     assert amp33.shape == (Dims.N_FRAMES, Dims.N_ROWS, Const.CHAN_WIDTH)
 
-    datamodel.data = u.Quantity(
-        detector, unit=datamodel.data.unit, dtype=datamodel.data.dtype
-    )
-    datamodel.amp33 = u.Quantity(
-        amp33, unit=datamodel.amp33.unit, dtype=datamodel.amp33.dtype
-    )
+    datamodel.data = detector
+    datamodel.amp33 = amp33.astype(datamodel.amp33.dtype)
 
     datamodel.border_ref_pix_left = datamodel.data[:, :, : Const.REF]
     datamodel.border_ref_pix_right = datamodel.data[:, :, -Const.REF :]

--- a/romancal/refpix/tests/test_data.py
+++ b/romancal/refpix/tests/test_data.py
@@ -57,13 +57,13 @@ class TestStandardView:
         assert standard.data.base is None
 
         # Check the relationship between the standard view and the datamodel
-        assert (standard.detector == datamodel.data.value).all()
-        assert (standard.left == datamodel.border_ref_pix_left.value).all()
-        assert (standard.right == datamodel.border_ref_pix_right.value).all()
+        assert (standard.detector == datamodel.data).all()
+        assert (standard.left == datamodel.border_ref_pix_left).all()
+        assert (standard.right == datamodel.border_ref_pix_right).all()
 
         # The amp33's dtype changes because it needs to be promoted to match that
         # of the rest of the data
-        assert (standard.amp33 == datamodel.amp33.value.astype(np.float32)).all()
+        assert (standard.amp33 == datamodel.amp33.astype(np.float32)).all()
 
     def test_update(self, datamodel):
         standard = StandardView.from_datamodel(datamodel)
@@ -97,20 +97,14 @@ class TestStandardView:
         assert new.border_ref_pix_left.dtype == old_left.dtype
         assert new.border_ref_pix_right.dtype == old_right.dtype
 
-        # Check the unit has been preserved
-        assert new.data.unit == old_detector.unit
-        assert new.amp33.unit == old_amp33.unit
-        assert new.border_ref_pix_left.unit == old_left.unit
-        assert new.border_ref_pix_right.unit == old_right.unit
-
         # Check the data has been updated correctly
-        assert (new.data.value == standard.detector).all()
-        assert (new.border_ref_pix_left.value == standard.left).all()
-        assert (new.border_ref_pix_right.value == standard.right).all()
+        assert (new.data == standard.detector).all()
+        assert (new.border_ref_pix_left == standard.left).all()
+        assert (new.border_ref_pix_right == standard.right).all()
 
         # The amp33's dtype changes because it needs to be shifted to match the
         # original data's dtype
-        assert (new.amp33.value == standard.amp33.astype(old_amp33.dtype)).all()
+        assert (new.amp33 == standard.amp33.astype(old_amp33.dtype)).all()
 
     def test_create_standard_view(self, data):
         """

--- a/romancal/refpix/tests/test_refpix.py
+++ b/romancal/refpix/tests/test_refpix.py
@@ -14,9 +14,5 @@ def test_run_steps_regression(datamodel, ref_pix_ref):
 
     result = run_steps(datamodel, ref_pix_ref, True, True, True, True)
 
-    assert (result.data.value == regression_out).all()
+    assert (result.data == regression_out).all()
     # regression_out does not return amp33 data
-
-    # Check the units
-    assert result.data.unit == u.DN
-    assert result.amp33.unit == u.DN

--- a/romancal/refpix/tests/test_step.py
+++ b/romancal/refpix/tests/test_step.py
@@ -43,21 +43,17 @@ def test_refpix_step(
     assert result is not regression
 
     # Check the data
-    assert (result.data.value == regression.data.value).all()
-    assert result.data.unit == regression.data.unit
+    assert (result.data == regression.data).all()
     # Check the amp33
-    assert (result.amp33.value == regression.amp33.value).all()
-    assert result.amp33.unit == regression.amp33.unit
+    assert (result.amp33 == regression.amp33).all()
     # Check left ref pix
     assert (
-        result.border_ref_pix_left.value == regression.border_ref_pix_left.value
+        result.border_ref_pix_left == regression.border_ref_pix_left
     ).all()
-    assert result.border_ref_pix_left.unit == regression.border_ref_pix_left.unit
     # Check right ref pix
     assert (
-        result.border_ref_pix_right.value == regression.border_ref_pix_right.value
+        result.border_ref_pix_right == regression.border_ref_pix_right
     ).all()
-    assert result.border_ref_pix_right.unit == regression.border_ref_pix_right.unit
     #
     # Run the step with reffile = N/A
     result = RefPixStep.call(

--- a/romancal/saturation/saturation.py
+++ b/romancal/saturation/saturation.py
@@ -34,7 +34,7 @@ def flag_saturation(input_model, ref_model):
         The input model is modified in place and returned as the output model.
     """
 
-    data = input_model.data[np.newaxis, :].value
+    data = input_model.data[np.newaxis, :]
 
     # Modify input_model in place.
     gdq = input_model.groupdq[np.newaxis, :]

--- a/romancal/saturation/tests/test_saturation.py
+++ b/romancal/saturation/tests/test_saturation.py
@@ -27,11 +27,11 @@ def test_basic_saturation_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 0 * ramp.data.unit
-    ramp.data[1, 5, 5] = 20000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit  # Signal reaches saturation limit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit
+    ramp.data[0, 5, 5] = 0
+    ramp.data[1, 5, 5] = 20000
+    ramp.data[2, 5, 5] = 40000
+    ramp.data[3, 5, 5] = 60000  # Signal reaches saturation limit
+    ramp.data[4, 5, 5] = 62000
 
     # Set saturation value in the saturation model
     satmap.data[5, 5] = satvalue * satmap.data.unit
@@ -40,7 +40,7 @@ def test_basic_saturation_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Make sure that groups with signal > saturation limit get flagged
-    satindex = np.argmax(output.data.value[:, 5, 5] == satvalue)
+    satindex = np.argmax(output.data[:, 5, 5] == satvalue)
     assert np.all(output.groupdq[satindex:, 5, 5] == group.SATURATED)
 
 
@@ -56,11 +56,11 @@ def test_read_pattern_saturation_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 0 * ramp.data.unit
-    ramp.data[1, 5, 5] = 20000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit  # Signal reaches saturation limit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit
+    ramp.data[0, 5, 5] = 0
+    ramp.data[1, 5, 5] = 20000
+    ramp.data[2, 5, 5] = 40000
+    ramp.data[3, 5, 5] = 60000  # Signal reaches saturation limit
+    ramp.data[4, 5, 5] = 62000
 
     # set read_pattern to have many reads in the third resultant, so that
     # its mean exposure time is much smaller than its last read time
@@ -100,11 +100,11 @@ def test_ad_floor_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
-    ramp.data[1, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
-    ramp.data[2, 5, 5] = 20 * ramp.data.unit
-    ramp.data[3, 5, 5] = 40 * ramp.data.unit
-    ramp.data[4, 5, 5] = 60 * ramp.data.unit
+    ramp.data[0, 5, 5] = 0  # Signal at bottom rail - low saturation
+    ramp.data[1, 5, 5] = 0  # Signal at bottom rail - low saturation
+    ramp.data[2, 5, 5] = 20
+    ramp.data[3, 5, 5] = 40
+    ramp.data[4, 5, 5] = 60
 
     # frames that should be flagged as saturation (low)
     satindxs = [0, 1]
@@ -134,11 +134,11 @@ def test_ad_floor_and_saturation_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
-    ramp.data[1, 5, 5] = 0 * ramp.data.unit  # Signal at bottom rail - low saturation
-    ramp.data[2, 5, 5] = 20 * ramp.data.unit
-    ramp.data[3, 5, 5] = 40 * ramp.data.unit
-    ramp.data[4, 5, 5] = 61000 * ramp.data.unit  # Signal above the saturation threshold
+    ramp.data[0, 5, 5] = 0  # Signal at bottom rail - low saturation
+    ramp.data[1, 5, 5] = 0  # Signal at bottom rail - low saturation
+    ramp.data[2, 5, 5] = 20
+    ramp.data[3, 5, 5] = 40
+    ramp.data[4, 5, 5] = 61000  # Signal above the saturation threshold
 
     # frames that should be flagged as ad_floor
     floorindxs = [0, 1]
@@ -171,11 +171,11 @@ def test_signal_fluctuation_flagging(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 10 * ramp.data.unit
-    ramp.data[1, 5, 5] = 20000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit  # Signal reaches saturation limit
-    ramp.data[4, 5, 5] = 40000 * ramp.data.unit  # Signal drops below saturation limit
+    ramp.data[0, 5, 5] = 10
+    ramp.data[1, 5, 5] = 20000
+    ramp.data[2, 5, 5] = 40000
+    ramp.data[3, 5, 5] = 60000  # Signal reaches saturation limit
+    ramp.data[4, 5, 5] = 40000  # Signal drops below saturation limit
 
     # Set saturation value in the saturation model
     satmap.data[5, 5] = satvalue * satmap.data.unit
@@ -184,7 +184,7 @@ def test_signal_fluctuation_flagging(setup_wfi_datamodels):
     output = flag_saturation(ramp, satmap)
 
     # Make sure that all groups after first saturated group are flagged
-    satindex = np.argmax(output.data.value[:, 5, 5] == satvalue)
+    satindex = np.argmax(output.data[:, 5, 5] == satvalue)
     assert np.all(output.groupdq[satindex:, 5, 5] == group.SATURATED)
 
 
@@ -200,11 +200,11 @@ def test_all_groups_saturated(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values at or above saturation limit
-    ramp.data[0, 5, 5] = 60000 * ramp.data.unit
-    ramp.data[1, 5, 5] = 62000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 62000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit
+    ramp.data[0, 5, 5] = 60000
+    ramp.data[1, 5, 5] = 62000
+    ramp.data[2, 5, 5] = 62000
+    ramp.data[3, 5, 5] = 60000
+    ramp.data[4, 5, 5] = 62000
 
     # Set saturation value in the saturation model
     satmap.data[5, 5] = satvalue * satmap.data.unit
@@ -252,11 +252,11 @@ def test_no_sat_check(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 10 * ramp.data.unit
-    ramp.data[1, 5, 5] = 20000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit  # Signal reaches saturation limit
+    ramp.data[0, 5, 5] = 10
+    ramp.data[1, 5, 5] = 20000
+    ramp.data[2, 5, 5] = 40000
+    ramp.data[3, 5, 5] = 60000
+    ramp.data[4, 5, 5] = 62000  # Signal reaches saturation limit
 
     # Set saturation value in the saturation model & DQ value for NO_SAT_CHECK
     satmap.data[5, 5] = satvalue * satmap.data.unit
@@ -291,11 +291,11 @@ def test_nans_in_mask(setup_wfi_datamodels):
     ramp, satmap = setup_wfi_datamodels(ngroups, nrows, ncols)
 
     # Add ramp values up to the saturation limit
-    ramp.data[0, 5, 5] = 10 * ramp.data.unit
-    ramp.data[1, 5, 5] = 20000 * ramp.data.unit
-    ramp.data[2, 5, 5] = 40000 * ramp.data.unit
-    ramp.data[3, 5, 5] = 60000 * ramp.data.unit
-    ramp.data[4, 5, 5] = 62000 * ramp.data.unit
+    ramp.data[0, 5, 5] = 10
+    ramp.data[1, 5, 5] = 20000
+    ramp.data[2, 5, 5] = 40000
+    ramp.data[3, 5, 5] = 60000
+    ramp.data[4, 5, 5] = 62000
 
     # Set saturation value for pixel to NaN
     satmap.data[5, 5] = np.nan * satmap.data.unit
@@ -324,9 +324,7 @@ def test_saturation_getbestref(setup_wfi_datamodels):
     wfi_sci_raw.meta["guidestar"]["gw_window_xstart"] = 1012
     wfi_sci_raw.meta["guidestar"]["gw_window_xsize"] = 16
     wfi_sci_raw.meta.exposure.type = "WFI_IMAGE"
-    wfi_sci_raw.data = u.Quantity(
-        np.ones(shape, dtype=np.uint16), u.DN, dtype=np.uint16
-    )
+    wfi_sci_raw.data = np.ones(shape, dtype=np.uint16)
     wfi_sci_raw_model = ScienceRawModel(wfi_sci_raw, dq=True)
 
     # Run the pipeline


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>

## Summary by Sourcery

Remove units from data arrays across multiple modules, including saturation, refpix, flatfield, dq_init, ramp_fitting, dark_current, and linearity, to streamline data processing and improve performance. Update associated test cases to align with these changes.

Enhancements:
- Remove units from data arrays in various modules to simplify data handling and improve performance.

Tests:
- Update test cases to reflect the removal of units from data arrays, ensuring compatibility with the new data structure.