### PR TITLE
Rcal 932 remove units in exposure level pipeline

### DIFF
--- a/romancal/regtest/test_catalog.py
+++ b/romancal/regtest/test_catalog.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
     scope="module",
     params=[
         "r0099101001001001001_F158_visit_i2d.asdf",
-        "r0000101001001001001_01101_0001_WFI01_cal.asdf",
+        "r0000101001001001001_0001_WFI01_cal.asdf",
     ],
     ids=["L3", "L2"],
 )

--- a/romancal/regtest/test_dark_current.py
+++ b/romancal/regtest/test_dark_current.py
@@ -12,13 +12,13 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
     """Function to run and compare Dark Current subtraction files. Note: This
     should include tests for overrides etc."""
 
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    input_datafile = "r0000101001001001001_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
     args = ["romancal.step.DarkCurrentStep", rtdata.input]
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    output = "r0000101001001001001_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
@@ -29,7 +29,7 @@ def test_dark_current_subtraction_step(rtdata, ignore_asdf_paths):
 def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
     """Function to run and compare Dark Current subtraction files. Here the
     test is for renaming the output file."""
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    input_datafile = "r0000101001001001001_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
@@ -50,7 +50,7 @@ def test_dark_current_outfile_step(rtdata, ignore_asdf_paths):
 def test_dark_current_outfile_suffix(rtdata, ignore_asdf_paths):
     """Function to run and compare Dark Current subtraction files. Here the
     test is for renaming the output file."""
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    input_datafile = "r0000101001001001001_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
@@ -73,10 +73,10 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
     """Function to run and compare Dark Current subtraction files. Here the
     test for overriding the CRDS dark reference file."""
 
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    input_datafile = "r0000101001001001001_0001_WFI01_linearity.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
-    dark_output_name = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    dark_output_name = "r0000101001001001001_0001_WFI01_darkcurrent.asdf"
 
     args = [
         "romancal.step.DarkCurrentStep",
@@ -84,7 +84,7 @@ def test_dark_current_output(rtdata, ignore_asdf_paths):
         f"--dark_output={dark_output_name}",
     ]
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    output = "r0000101001001001001_0001_WFI01_darkcurrent.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)

--- a/romancal/regtest/test_jump_det.py
+++ b/romancal/regtest/test_jump_det.py
@@ -13,7 +13,7 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
     """Function to run and compare Jump Detection files. Note: This should
     include tests for overrides etc."""
 
-    input_file = "r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_darkcurrent.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -29,7 +29,7 @@ def test_jump_detection_step(rtdata, ignore_asdf_paths):
         "--run_ramp_jump_detection=False",
     ]
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_jump.asdf"
+    output = "r0000101001001001001_0001_WFI01_jump.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)

--- a/romancal/regtest/test_linearity.py
+++ b/romancal/regtest/test_linearity.py
@@ -10,13 +10,13 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_linearity_step(rtdata, ignore_asdf_paths):
     """Function to run and compare linearity correction files."""
-    input_file = "r0000101001001001001_01101_0001_WFI01_refpix.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_refpix.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
     args = ["romancal.step.LinearityStep", rtdata.input]
     RomanStep.from_cmdline(args)
-    output = "r0000101001001001001_01101_0001_WFI01_linearity.asdf"
+    output = "r0000101001001001001_0001_WFI01_linearity.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
     diff = compare_asdf(rtdata.output, rtdata.truth, **ignore_asdf_paths)
@@ -27,7 +27,7 @@ def test_linearity_step(rtdata, ignore_asdf_paths):
 def test_linearity_outfile_step(rtdata, ignore_asdf_paths):
     """Function to run and linearity correction files. Here the
     test is for renaming the output file."""
-    input_file = "r0000101001001001001_01101_0001_WFI01_refpix.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_refpix.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 

--- a/romancal/regtest/test_ramp_fitting.py
+++ b/romancal/regtest/test_ramp_fitting.py
@@ -100,22 +100,22 @@ CONDITIONS_TRUNC = CONDITIONS_FULL + [cond_is_truncated]
     params=[
         (
             "DMS362",
-            Path("WFI/image/r0000101001001001001_01101_0001_WFI01_darkcurrent.asdf"),
+            Path("WFI/image/r0000101001001001001_0001_WFI01_darkcurrent.asdf"),
             CONDITIONS_FULL,
         ),
         (
             "DMS366",
-            Path("WFI/grism/r0000201001001001001_01101_0001_WFI01_darkcurrent.asdf"),
+            Path("WFI/grism/r0000201001001001001_0001_WFI01_darkcurrent.asdf"),
             CONDITIONS_FULL,
         ),
         (
             "DMS363",
-            Path("WFI/image/r0000101001001001001_01101_0003_WFI01_darkcurrent.asdf"),
+            Path("WFI/image/r0000101001001001001_0003_WFI01_darkcurrent.asdf"),
             CONDITIONS_TRUNC,
         ),
         (
             "DMS367",
-            Path("WFI/grism/r0000201001001001001_01101_0003_WFI01_darkcurrent.asdf"),
+            Path("WFI/grism/r0000201001001001001_0003_WFI01_darkcurrent.asdf"),
             CONDITIONS_TRUNC,
         ),
     ],

--- a/romancal/regtest/test_refpix.py
+++ b/romancal/regtest/test_refpix.py
@@ -10,7 +10,7 @@ from .regtestdata import compare_asdf
 @pytest.mark.bigdata
 def test_refpix_step(rtdata, ignore_asdf_paths):
     # I have no idea what this is supposed to be
-    input_datafile = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
+    input_datafile = "r0000101001001001001_0001_WFI01_saturation.asdf"
     rtdata.get_data(f"WFI/image/{input_datafile}")
     rtdata.input = input_datafile
 
@@ -18,7 +18,7 @@ def test_refpix_step(rtdata, ignore_asdf_paths):
     RomanStep.from_cmdline(args)
 
     # Again I have no idea here
-    output = "r0000101001001001001_01101_0001_WFI01_refpix.asdf"
+    output = "r0000101001001001001_0001_WFI01_refpix.asdf"
     rtdata.output = output
     rtdata.get_truth(f"truth/WFI/image/{output}")
 

--- a/romancal/regtest/test_tweakreg.py
+++ b/romancal/regtest/test_tweakreg.py
@@ -16,11 +16,11 @@ def test_tweakreg(rtdata, ignore_asdf_paths, tmp_path):
     # ``shifted'' version is created in make_regtestdata.sh; cal file is taken,
     # the wcsinfo is perturbed, and AssignWCS is run to update the WCS with the
     # perturbed information
-    orig_uncal = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
-    orig_catfile = "r0000101001001001001_01101_0001_WFI01_cat.asdf"
-    input_data = "r0000101001001001001_01101_0001_WFI01_shift_cal.asdf"
-    output_data = "r0000101001001001001_01101_0001_WFI01_shift_tweakregstep.asdf"
-    truth_data = "r0000101001001001001_01101_0001_WFI01_shift_tweakregstep.asdf"
+    orig_uncal = "r0000101001001001001_0001_WFI01_uncal.asdf"
+    orig_catfile = "r0000101001001001001_0001_WFI01_cat.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_shift_cal.asdf"
+    output_data = "r0000101001001001001_0001_WFI01_shift_tweakregstep.asdf"
+    truth_data = "r0000101001001001001_0001_WFI01_shift_tweakregstep.asdf"
 
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.get_data(f"WFI/image/{orig_catfile}")

--- a/romancal/regtest/test_wfi_dq_init.py
+++ b/romancal/regtest/test_wfi_dq_init.py
@@ -16,7 +16,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     """DMS25 Test: Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
-    input_file = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -40,7 +40,7 @@ def test_dq_init_image_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_mask" in ref_file_name
 
     # Test DQInitStep
-    output = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
+    output = "r0000101001001001001_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
     step.log.info(
@@ -71,7 +71,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     """DMS25 Test: Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected mask file applied."""
 
-    input_file = "r0000201001001001001_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -95,7 +95,7 @@ def test_dq_init_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_mask" in ref_file_name
 
     # Test DQInitStep
-    output = "r0000201001001001001_01101_0001_WFI01_dqinit.asdf"
+    output = "r0000201001001001001_0001_WFI01_dqinit.asdf"
     rtdata.output = output
     args = ["romancal.step.DQInitStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_flat_field.py
+++ b/romancal/regtest/test_wfi_flat_field.py
@@ -14,7 +14,7 @@ from .regtestdata import compare_asdf
 def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     """Test for the flat field step using imaging data."""
 
-    input_data = "r0000101001001001001_01101_0001_WFI01_assignwcs.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
@@ -25,7 +25,7 @@ def test_flat_field_image_step(rtdata, ignore_asdf_paths):
     ref_file_name = os.path.split(ref_file_path)[-1]
     assert "roman_wfi_flat" in ref_file_name
     # Test FlatFieldStep
-    output = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
+    output = "r0000101001001001001_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
@@ -40,7 +40,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     the grism and prism data should be None, only testing the grism
     case here."""
 
-    input_file = "r0000201001001001001_01101_0001_WFI01_uncal.asdf"
+    input_file = "r0000201001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -59,7 +59,7 @@ def test_flat_field_grism_step(rtdata, ignore_asdf_paths):
     assert ref_file_name == "N/A"
 
     # Test FlatFieldStep
-    output = "r0000201001001001001_01101_0001_WFI01_flat.asdf"
+    output = "r0000201001001001001_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     RomanStep.from_cmdline(args)
@@ -75,7 +75,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     flat files and successfully make level 2 output"""
 
     # First file
-    input_l2_file = "r0000101001001001001_01101_0001_WFI01_assignwcs.asdf"
+    input_l2_file = "r0000101001001001001_0001_WFI01_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_l2_file}")
     rtdata.input = input_l2_file
 
@@ -102,7 +102,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     )
 
     # Test FlatFieldStep
-    output = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
+    output = "r0000101001001001001_0001_WFI01_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     step.log.info(
@@ -126,7 +126,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     #  to separate flat files in CRDS.
 
     # Second file
-    input_file = "r0000101001001001001_01101_0001_WFI01_changetime_assignwcs.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_changetime_assignwcs.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -149,7 +149,7 @@ def test_flat_field_crds_match_image_step(rtdata, ignore_asdf_paths):
     )
 
     # Test FlatFieldStep
-    output = "r0000101001001001001_01101_0001_WFI01_changetime_flat.asdf"
+    output = "r0000101001001001001_0001_WFI01_changetime_flat.asdf"
     rtdata.output = output
     args = ["romancal.step.FlatFieldStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_grism_16resultants.py
+++ b/romancal/regtest/test_wfi_grism_16resultants.py
@@ -16,12 +16,12 @@ def run_elp(rtdata_module):
     # The input data is from INS for stress testing at some point this should be generated
     # by INS every time new data is needed.
 
-    input_data = "r0000201001001001001_01101_0004_WFI01_uncal.asdf"
+    input_data = "r0000201001001001001_0004_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r0000201001001001001_01101_0004_WFI01_cal.asdf"
+    output = "r0000201001001001001_0004_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "roman_elp",

--- a/romancal/regtest/test_wfi_grism_pipeline.py
+++ b/romancal/regtest/test_wfi_grism_pipeline.py
@@ -19,12 +19,12 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.soctests]
 def run_elp(rtdata_module):
     rtdata = rtdata_module
 
-    input_data = "r0000201001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000201001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/grism/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r0000201001001001001_01101_0001_WFI01_cal.asdf"
+    output = "r0000201001001001001_0001_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "roman_elp",

--- a/romancal/regtest/test_wfi_image_16resultants.py
+++ b/romancal/regtest/test_wfi_image_16resultants.py
@@ -16,12 +16,12 @@ def run_elp(rtdata_module):
     # The input data is from INS for stress testing at some point this should be generated
     # every time new data is needed.
 
-    input_data = "r0000101001001001001_01101_0004_WFI01_uncal.asdf"
+    input_data = "r0000101001001001001_0004_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r0000101001001001001_01101_0004_WFI01_cal.asdf"
+    output = "r0000101001001001001_0004_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "roman_elp",

--- a/romancal/regtest/test_wfi_image_pipeline.py
+++ b/romancal/regtest/test_wfi_image_pipeline.py
@@ -20,12 +20,12 @@ pytestmark = pytest.mark.bigdata
 def run_elp(rtdata_module):
     rtdata = rtdata_module
 
-    input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
+    output = "r0000101001001001001_0001_WFI01_cal.asdf"
     rtdata.output = output
     args = [
         "roman_elp",
@@ -205,12 +205,12 @@ def test_repointed_wcs_differs(repointed_filename_and_delta, output_model):
 
 def test_elp_input_dm(rtdata, ignore_asdf_paths):
     """Test for input roman Datamodel to exposure level pipeline"""
-    input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     dm_input = rdm.open(rtdata.input)
 
     # Test Pipeline with input datamodel
-    output = "r0000101001001001001_01101_0001_WFI01_cal.asdf"
+    output = "r0000101001001001001_0001_WFI01_cal.asdf"
     rtdata.output = output
     ExposurePipeline.call(dm_input, save_results=True)
     rtdata.get_truth(f"truth/WFI/image/{output}")
@@ -234,12 +234,12 @@ def test_processing_pipeline_all_saturated(rtdata, ignore_asdf_paths):
     Note that this test mimics how the pipeline is run in OPS.
     Any changes to this test should be coordinated with OPS.
     """
-    input_data = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_uncal.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_ALL_SATURATED_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
     # Test Pipeline
-    output = "r0000101001001001001_01101_0001_WFI01_ALL_SATURATED_cal.asdf"
+    output = "r0000101001001001001_0001_WFI01_ALL_SATURATED_cal.asdf"
     rtdata.output = output
     args = [
         "roman_elp",
@@ -272,10 +272,10 @@ def test_pipeline_suffix(rtdata, ignore_asdf_paths):
 
     Any changes to this test should be coordinated with OPS.
     """
-    input_data = "r0000101001001001001_01101_0001_WFI01_uncal.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_uncal.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
 
-    output = "r0000101001001001001_01101_0001_WFI01_star.asdf"
+    output = "r0000101001001001001_0001_WFI01_star.asdf"
     rtdata.output = output
 
     args = [

--- a/romancal/regtest/test_wfi_photom.py
+++ b/romancal/regtest/test_wfi_photom.py
@@ -16,7 +16,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     """DMS140 Test: Testing application of photometric correction using
     CRDS selected photom file."""
 
-    input_data = "r0000101001001001001_01101_0001_WFI01_flat.asdf"
+    input_data = "r0000101001001001001_0001_WFI01_flat.asdf"
     rtdata.get_data(f"WFI/image/{input_data}")
     rtdata.input = input_data
 
@@ -39,7 +39,7 @@ def test_absolute_photometric_calibration(rtdata, ignore_asdf_paths):
     # photom match from CRDS. Values come from roman_wfi_photom_0034.asdf
 
     # Test PhotomStep
-    output = "r0000101001001001001_01101_0001_WFI01_photom.asdf"
+    output = "r0000101001001001001_0001_WFI01_photom.asdf"
     rtdata.output = output
     args = ["romancal.step.PhotomStep", rtdata.input]
     step.log.info(

--- a/romancal/regtest/test_wfi_saturation.py
+++ b/romancal/regtest/test_wfi_saturation.py
@@ -16,7 +16,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     """Testing retrieval of best ref file for image data,
     and creation of a ramp file with CRDS selected saturation file applied."""
 
-    input_file = "r0000101001001001001_01101_0001_WFI01_dqinit.asdf"
+    input_file = "r0000101001001001001_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/image/{input_file}")
     rtdata.input = input_file
 
@@ -30,7 +30,7 @@ def test_saturation_image_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_saturation" in ref_file_name
 
     # Test SaturationStep
-    output = "r0000101001001001001_01101_0001_WFI01_saturation.asdf"
+    output = "r0000101001001001001_0001_WFI01_saturation.asdf"
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]
@@ -49,7 +49,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     """Testing retrieval of best ref file for grism data,
     and creation of a ramp file with CRDS selected saturation file applied."""
 
-    input_file = "r0000201001001001001_01101_0001_WFI01_dqinit.asdf"
+    input_file = "r0000201001001001001_0001_WFI01_dqinit.asdf"
     rtdata.get_data(f"WFI/grism/{input_file}")
     rtdata.input = input_file
 
@@ -63,7 +63,7 @@ def test_saturation_grism_step(rtdata, ignore_asdf_paths):
     assert "roman_wfi_saturation" in ref_file_name
 
     # Test SaturationStep
-    output = "r0000201001001001001_01101_0001_WFI01_saturation.asdf"
+    output = "r0000201001001001001_0001_WFI01_saturation.asdf"
     rtdata.output = output
 
     args = ["romancal.step.SaturationStep", rtdata.input]

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -3,15 +3,15 @@
 # takes one argument: the directory into which to start putting the regtest files.
 
 # input files needed:
-# r0000101001001001001_01101_0001_WFI01 - default for most steps
-# r0000201001001001001_01101_0001_WFI01 - equivalent for spectroscopic data
-# r0000101001001001001_01101_0002_WFI01 - a second resample exposure, only cal step needed
-# r0000101001001001001_01101_0003_WFI01 - for ramp fitting; truncated image
-# r0000201001001001001_01101_0003_WFI01 - for ramp fitting; truncated spectroscopic
+# r0000101001001001001_0001_WFI01 - default for most steps
+# r0000201001001001001_0001_WFI01 - equivalent for spectroscopic data
+# r0000101001001001001_0002_WFI01 - a second resample exposure, only cal step needed
+# r0000101001001001001_0003_WFI01 - for ramp fitting; truncated image
+# r0000201001001001001_0003_WFI01 - for ramp fitting; truncated spectroscopic
 #                                         we need only darkcurrent & ramp fit for these
 #
-# r00r1601001001001001_01101_0001_WFI01 - special 16 resultant file, imaging, only need cal file
-# r10r1601001001001001_01101_0001_WFI01 - special 16 resultant file, spectroscopy, only need cal file
+# r00r1601001001001001_0001_WFI01 - special 16 resultant file, imaging, only need cal file
+# r10r1601001001001001_0001_WFI01 - special 16 resultant file, spectroscopy, only need cal file
 # roman_dark_WFI01_IMAGE_STRESS_TEST_16_MA_TABLE_998_D1 - special dark for 16 resultant file
 
 outdir=$1
@@ -24,7 +24,7 @@ mkdir -p $outdir/roman-pipeline/dev/truth/WFI/grism
 
 
 # most regtests; run the pipeline and save a lot of results.
-for fn in r0000101001001001001_01101_0001_WFI01 r0000201001001001001_01101_0001_WFI01
+for fn in r0000101001001001001_0001_WFI01 r0000201001001001001_0001_WFI01
 do
     echo "Running pipeline on ${fn}..."
     strun roman_elp ${fn}_uncal.asdf --steps.dq_init.save_results True --steps.saturation.save_results True --steps.linearity.save_results True --steps.dark_current.save_results True --steps.rampfit.save_results True --steps.assign_wcs.save_results True --steps.photom.save_results True --steps.refpix.save_results True --steps.flatfield.save_results True --steps.assign_wcs.save_results True
@@ -38,7 +38,7 @@ done
 
 
 # truncated files for ramp fit regtests
-for fn in r0000101001001001001_01101_0003_WFI01 r0000201001001001001_01101_0003_WFI01
+for fn in r0000101001001001001_0003_WFI01 r0000201001001001001_0003_WFI01
 do
     echo "Running pipeline on ${fn}..."
     strun roman_elp ${fn}_uncal.asdf --steps.dark_current.save_results True --steps.rampfit.save_results True
@@ -46,29 +46,35 @@ do
     cp ${fn}_darkcurrent.asdf $outdir/roman-pipeline/dev/WFI/$dirname/
     cp ${fn}_rampfit.asdf $outdir/roman-pipeline/dev/truth/WFI/$dirname/
 done
-cp r0000101001001001001_01101_0003_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp r0000101001001001001_0003_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
 
 
 # second imaging exposure
-strun roman_elp r0000101001001001001_01101_0002_WFI01_uncal.asdf
-cp r0000101001001001001_01101_0002_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
+strun roman_elp r0000101001001001001_0002_WFI01_uncal.asdf
+cp r0000101001001001001_0002_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image/
 
 
-# resample regtest; needs r0000101001001001001_01101_000{1,2}_WFI01_cal.asdf
+# resample regtest; needs r0000101001001001001_000{1,2}_WFI01_cal.asdf
 # builds the appropriate asn file and calls strun with it
 echo "Creating regtest files for resample..."
+<<<<<<< Updated upstream
 asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf -o L3_mosaic_asn.json --product-name mosaic
 strun romancal.step.ResampleStep L3_mosaic_asn.json --rotation=0 --output_file=mosaic.asdf
 cp L3_mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
+=======
+asn_from_list r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf -o mosaic_asn.json --product-name mosaic
+strun romancal.step.ResampleStep mosaic_asn.json --rotation=0 --output_file=mosaic.asdf
+cp mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
+>>>>>>> Stashed changes
 cp mosaic_resamplestep.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 
 
-# CRDS test needs the "usual" r00001..._01101_0001_WFI01 files.
-# It also needs a hacked r00001..._01101_0001_WFI01 file, with the time changed.
+# CRDS test needs the "usual" r00001..._0001_WFI01 files.
+# It also needs a hacked r00001..._0001_WFI01 file, with the time changed.
 # this makes the hacked version.
 echo "Creating regtest files for CRDS tests..."
-basename="r0000101001001001001_01101_0001_WFI01"
+basename="r0000101001001001001_0001_WFI01"
 python -c "
 import asdf
 from roman_datamodels import stnode
@@ -86,14 +92,14 @@ cp ${basename}_changetime_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/image
 
 # need to make a special ALL_SATURATED file for the all saturated test.
 echo "Creating regtest files for all saturated tests..."
-basename="r0000101001001001001_01101_0001_WFI01"
+basename="r0000101001001001001_0001_WFI01"
 python -c "
 import asdf
 from roman_datamodels import stnode
 basename = '$basename'
 f = asdf.open(f'{basename}_uncal.asdf')
 data = f['roman']['data'].copy()
-data[...] = 65535 * f['roman']['data'].unit
+data[...] = 65535
 f['roman']['data'] = data
 f['roman']['meta']['filename'] = stnode.Filename(f'{basename}_ALL_SATURATED_uncal.asdf')
 f.write_to(f'{basename}_ALL_SATURATED_uncal.asdf')"
@@ -103,19 +109,19 @@ cp ${basename}_ALL_SATURATED_cal.asdf $outdir/roman-pipeline/dev/truth/WFI/image
 
 
 # make a special file dark file with a different name
-strun romancal.step.DarkCurrentStep r0000101001001001001_01101_0001_WFI01_linearity.asdf --output_file=Test_dark
+strun romancal.step.DarkCurrentStep r0000101001001001001_0001_WFI01_linearity.asdf --output_file=Test_dark
 cp Test_darkcurrent.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 
 # make a special linearity file with a different suffix
-strun romancal.step.LinearityStep r0000101001001001001_01101_0001_WFI01_refpix.asdf --output_file=Test_linearity
+strun romancal.step.LinearityStep r0000101001001001001_0001_WFI01_refpix.asdf --output_file=Test_linearity
 cp Test_linearity.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 
 # we have a test that runs the flat field step directly on an _L1_ spectroscopic
 # file and verifies that it gets skipped.
 # I don't really understand that but we can duplicate it for now.
-basename="r0000201001001001001_01101_0001_WFI01"
+basename="r0000201001001001001_0001_WFI01"
 strun romancal.step.FlatFieldStep ${basename}_uncal.asdf
 cp ${basename}_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/grism/
 
@@ -124,7 +130,7 @@ cp ${basename}_flat.asdf $outdir/roman-pipeline/dev/truth/WFI/grism/
 # we haven't updated the filename in these files, but the regtest mechanism
 # also doesn't
 # update them, and we need to match.
-for basename in r0000101001001001001_01101_0001_WFI01 r0000201001001001001_01101_0001_WFI01
+for basename in r0000101001001001001_0001_WFI01 r0000201001001001001_0001_WFI01
 do
     python -c "
 import asdf
@@ -146,7 +152,7 @@ model.to_asdf(f'${basename}_cal_repoint.asdf')"
 done
 
 # Test tweakreg with repointed file, only shifted by 1"
-for basename in r0000101001001001001_01101_0001_WFI01
+for basename in r0000101001001001001_0001_WFI01
 do
     python -c "
 import asdf
@@ -167,15 +173,22 @@ model.to_asdf(f'${basename}_shift_cal.asdf')"
 done
 
 
-strun roman_elp r0000101001001001001_01101_0004_WFI01_uncal.asdf
-strun roman_elp r0000201001001001001_01101_0004_WFI01_uncal.asdf
-cp r0000101001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
-cp r0000201001001001001_01101_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
+strun roman_elp r0000101001001001001_0004_WFI01_uncal.asdf
+strun roman_elp r0000201001001001001_0004_WFI01_uncal.asdf
+cp r0000101001001001001_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp r0000201001001001001_0004_WFI01_uncal.asdf $outdir/roman-pipeline/dev/WFI/grism/
 
 l3name="r0099101001001001001_F158_visit"
-asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name
+asn_from_list r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf r0000101001001001001_0003_WFI01_cal.asdf -o L3_regtest_asn.json --product-name $l3name
 strun roman_mos L3_regtest_asn.json
 cp L3_regtest_asn.json $outdir/roman-pipeline/dev/WFI/image/
+cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/WFI/image/
+cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+
+l3name="r0099101001001001001_r274dp63x31y81_prompt_F158"
+asn_from_list r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf r0000101001001001001_0003_WFI01_cal.asdf -o L3_mosaic_asn.json --product-name $l3name --target r274dp63x31y81
+strun roman_mos L3_mosaic_asn.json
+cp L3_mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
 cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/WFI/image/
 cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
@@ -184,10 +197,10 @@ strun romancal.step.SourceCatalogStep ${l3name}_i2d.asdf
 cp ${l3name}_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 # L2 catalog
-strun romancal.step.SourceCatalogStep r0000101001001001001_01101_0001_WFI01_cal.asdf
-cp r0000101001001001001_01101_0001_WFI01_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
+strun romancal.step.SourceCatalogStep r0000101001001001001_0001_WFI01_cal.asdf
+cp r0000101001001001001_0001_WFI01_cat.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
 
 l3name="mosaic"
-asn_from_list --product-name=$l3name r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf r0000101001001001001_01101_0003_WFI01_cal.asdf -o L3_m1_asn.json
+asn_from_list --product-name=$l3name r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf r0000101001001001001_0003_WFI01_cal.asdf -o L3_m1_asn.json
 strun roman_mos L3_m1_asn.json
 cp ${l3name}_i2d.asdf $outdir/roman-pipeline/dev/truth/WFI/image/

--- a/romancal/scripts/make_regtestdata.sh
+++ b/romancal/scripts/make_regtestdata.sh
@@ -57,17 +57,10 @@ cp r0000101001001001001_0002_WFI01_cal.asdf $outdir/roman-pipeline/dev/WFI/image
 # resample regtest; needs r0000101001001001001_000{1,2}_WFI01_cal.asdf
 # builds the appropriate asn file and calls strun with it
 echo "Creating regtest files for resample..."
-<<<<<<< Updated upstream
-asn_from_list r0000101001001001001_01101_0001_WFI01_cal.asdf r0000101001001001001_01101_0002_WFI01_cal.asdf -o L3_mosaic_asn.json --product-name mosaic
+asn_from_list r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf -o L3_mosaic_asn.json --product-name mosaic
 strun romancal.step.ResampleStep L3_mosaic_asn.json --rotation=0 --output_file=mosaic.asdf
 cp L3_mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
-=======
-asn_from_list r0000101001001001001_0001_WFI01_cal.asdf r0000101001001001001_0002_WFI01_cal.asdf -o mosaic_asn.json --product-name mosaic
-strun romancal.step.ResampleStep mosaic_asn.json --rotation=0 --output_file=mosaic.asdf
-cp mosaic_asn.json $outdir/roman-pipeline/dev/WFI/image/
->>>>>>> Stashed changes
 cp mosaic_resamplestep.asdf $outdir/roman-pipeline/dev/truth/WFI/image/
-
 
 
 # CRDS test needs the "usual" r00001..._0001_WFI01 files.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] **request a review from someone specific**, to avoid making the maintainers review every PR
- [ ] add a build milestone, i.e. `24Q4_B15` (use the [latest build](https://github.com/spacetelescope/romancal/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/romancal/wiki/How-to-resolve-JIRA-issues)

<details><summary>news fragment change types...</summary>

  - ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
  - ``changes/<PR#>.docs.rst``
  - ``changes/<PR#>.stpipe.rst``
  - ``changes/<PR#>.associations.rst``
  - ``changes/<PR#>.scripts.rst``
  - ``changes/<PR#>.mosaic_pipeline.rst``
  - ``changes/<PR#>.patch_match.rst``

  ## steps
  - ``changes/<PR#>.dq_init.rst``
  - ``changes/<PR#>.saturation.rst``
  - ``changes/<PR#>.refpix.rst``
  - ``changes/<PR#>.linearity.rst``
  - ``changes/<PR#>.dark_current.rst``
  - ``changes/<PR#>.jump_detection.rst``
  - ``changes/<PR#>.ramp_fitting.rst``
  - ``changes/<PR#>.assign_wcs.rst``
  - ``changes/<PR#>.flatfield.rst``
  - ``changes/<PR#>.photom.rst``
  - ``changes/<PR#>.flux.rst``
  - ``changes/<PR#>.source_detection.rst``
  - ``changes/<PR#>.tweakreg.rst``
  - ``changes/<PR#>.skymatch.rst``
  - ``changes/<PR#>.outlier_detection.rst``
  - ``changes/<PR#>.resample.rst``
  - ``changes/<PR#>.source_catalog.rst``
</details>

## Summary by Sourcery

Standardize file naming conventions in the exposure level pipeline by removing units from file names and update associated test cases to ensure compatibility.

Enhancements:
- Remove units from file names in the exposure level pipeline to standardize naming conventions.

Tests:
- Update test cases to reflect changes in file naming conventions, ensuring compatibility with the new standardized file names.